### PR TITLE
Move GA to the head

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,6 @@
     <meta charset="utf-8" />
     <title>landing-page</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-  </head>
-
-  <body>
-    <div id="root"></div>
-    <script src="bundle.js"></script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -18,5 +13,10 @@
       ga('create', 'UA-83869855-1', 'auto');
       ga('send', 'pageview');
     </script>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script src="bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This lets the asynchronous script start downloading before bundle.js is
downloaded and parsed (but still doesn’t block the page).