### PR TITLE
Provide base url

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>GoodCall.nyc</title>
+    <base href="https://goodcall.nyc" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="/assets/imgs/favicon.ico" type="image/x-icon">
     <script>
@@ -10,7 +11,6 @@
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
       ga('create', 'UA-83869855-1', 'auto');
       ga('send', 'pageview');
     </script>


### PR DESCRIPTION
This is needed to simplify some proxying shit for adwords. 

Basically, we want to proxy requests from labs.robinhood.org/goodcall/{path}, to goodcall.nyc/{path}. But, if the returned html/css loads any assets with root-relative URIs (as it does in many places atm), then the /goodcall/ in the robinhood.org url will break those assets from loading. So, using a base url forces those assets to load correctly.